### PR TITLE
Fix wrong work HideWhenFound with Odin

### DIFF
--- a/Editor/AutoHookAttributeStateUpdater.cs
+++ b/Editor/AutoHookAttributeStateUpdater.cs
@@ -1,0 +1,9 @@
+﻿using Sirenix.OdinInspector.Editor;
+
+namespace TNRD.Autohook
+{
+    public class AutoHookAttributeStateUpdater : AttributeStateUpdater<AutoHookAttribute>
+    {
+        public override void OnStateUpdate() => Property.State.Visible = !Attribute.HideWhenFound;
+    }
+}

--- a/Editor/TNRD.Autohook.Editor.cs
+++ b/Editor/TNRD.Autohook.Editor.cs
@@ -1,0 +1,5 @@
+﻿using Sirenix.OdinInspector.Editor;
+using TNRD.Autohook;
+
+[assembly: RegisterStateUpdater(typeof (AutoHookAttributeStateUpdater), 0.0)]
+    


### PR DESCRIPTION
When we use HideWhenFound without this fix, we get one field on top of another.