### PR TITLE
Update 1.0.2 - Fix ReadOnlyWhenFound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.2] - 2023-12-10
+
+### Fixed
+- Fixed ReadOnlyWhenFound
+
+### Updated
+- Package Display Name
+
 ## [1.0.1] - 2020-10-17
 
 ### Added

--- a/Editor/AutoHookPropertyDrawer.cs
+++ b/Editor/AutoHookPropertyDrawer.cs
@@ -41,7 +41,7 @@ namespace TNRD.Autohook
                 }
             }
 
-            EditorGUI.BeginDisabledGroup(autoHookAttribute.ReadOnlyWhenFound);
+            EditorGUI.BeginDisabledGroup(autoHookAttribute.ReadOnlyWhenFound && property.objectReferenceValue != null);
             EditorGUI.PropertyField(position, property, label);
             EditorGUI.EndDisabledGroup();
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "net.tnrd.autohook",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "displayName": "Auto Hook",
   "description": "A property drawer that auto assigns a reference",
   "unity": "2019.1",


### PR DESCRIPTION
Fix ReadOnlyWhenFound.

It previously disabled the property field regardless of whether the property had been found or not.

In this fix, it checks for the property's value and disables the field accordingly.